### PR TITLE
chore:  bastion updates for bria, bitcoin, lnd, k9s, bos

### DIFF
--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -48,7 +48,7 @@ mv ./kubectl /usr/local/bin
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 
 mkdir bria && cd bria \
-  && wget https://github.com/GaloyMoney/bria/releases/download/${bria_version}/bria-x86_64-unknown-linux-musl-${bria_version}.tar.gz -O bria.tar.gz \
+  && wget https://github.com/blinkbitcoin/bria/releases/download/${bria_version}/bria-x86_64-unknown-linux-musl-${bria_version}.tar.gz -O bria.tar.gz \
   && tar --strip-components=1 -xf bria.tar.gz \
   && mv bria /usr/local/bin && cd ../ && rm -rf ./bria
 

--- a/modules/inception/gcp/bastion.tf
+++ b/modules/inception/gcp/bastion.tf
@@ -1,12 +1,12 @@
 locals {
   tag              = "${local.name_prefix}-bastion"
-  bria_version     = "0.1.108"
-  bitcoin_version  = "25.2"
+  bria_version     = "0.1.114"
+  bitcoin_version  = "27.0"
   cepler_version   = "0.7.15"
-  lnd_version      = "0.18.0-beta"
+  lnd_version      = "0.18.5-beta"
   kubectl_version  = "1.30.4"
-  k9s_version      = "0.32.5"
-  bos_version      = "18.2.0"
+  k9s_version      = "0.50.6"
+  bos_version      = "19.4.14"
   kratos_version   = "0.11.1"
   opentofu_version = "1.8.2"
 }


### PR DESCRIPTION
matching the deployed versions for bria, bitcoin and lnd

setting the latest for k9s and bos