### PR TITLE
chore: bump to version which is already deployed

### DIFF
--- a/ci/build/pipeline.yml
+++ b/ci/build/pipeline.yml
@@ -68,7 +68,7 @@ jobs:
         TESTFLIGHT_ADMINS: []
         TF_VAR_gcp_project: infra-testflight
         TF_VAR_enable_services: false
-        BRANCH: kn/scrub_project
+        BRANCH: main
       run:
         path: pipeline-tasks/ci/tasks/gcp/bootstrap.sh
   - put: bootstrap-tf-state
@@ -121,7 +121,7 @@ jobs:
         TESTFLIGHT_ADMINS: []
         TF_VAR_gcp_project: infra-testflight
         TF_VAR_enable_services: false
-        BRANCH: kn/scrub_project
+        BRANCH: main
       run:
         path: pipeline-tasks/ci/tasks/gcp/inception.sh
 - name: gcp-testflight-platform
@@ -169,7 +169,7 @@ jobs:
         TESTFLIGHT_ADMINS: []
         TF_VAR_gcp_project: infra-testflight
         TF_VAR_enable_services: false
-        BRANCH: kn/scrub_project
+        BRANCH: main
       run:
         path: pipeline-tasks/ci/tasks/gcp/platform.sh
 - name: gcp-testflight-smoketest
@@ -218,7 +218,7 @@ jobs:
         TESTFLIGHT_ADMINS: []
         TF_VAR_gcp_project: infra-testflight
         TF_VAR_enable_services: false
-        BRANCH: kn/scrub_project
+        BRANCH: main
       run:
         path: pipeline-tasks/ci/tasks/gcp/smoketest.sh
 - name: gcp-testflight-postgresql
@@ -267,7 +267,7 @@ jobs:
         TESTFLIGHT_ADMINS: []
         TF_VAR_gcp_project: infra-testflight
         TF_VAR_enable_services: false
-        BRANCH: kn/scrub_project
+        BRANCH: main
       run:
         path: pipeline-tasks/ci/tasks/gcp/postgresql.sh
 - name: gcp-testflight-postgresql-cleanup
@@ -318,7 +318,7 @@ jobs:
         TESTFLIGHT_ADMINS: []
         TF_VAR_gcp_project: infra-testflight
         TF_VAR_enable_services: false
-        BRANCH: kn/scrub_project
+        BRANCH: main
       run:
         path: pipeline-tasks/ci/tasks/gcp/teardown-postgresql.sh
 - name: gcp-testflight-cleanup
@@ -373,7 +373,7 @@ jobs:
         TESTFLIGHT_ADMINS: []
         TF_VAR_gcp_project: infra-testflight
         TF_VAR_enable_services: false
-        BRANCH: kn/scrub_project
+        BRANCH: main
       run:
         path: pipeline-tasks/ci/tasks/gcp/teardown.sh
   - in_parallel:
@@ -426,7 +426,7 @@ jobs:
       - name: repo
       - name: galoy-staging
       params:
-        BRANCH: kn/scrub_project
+        BRANCH: main
         GITHUB_SSH_KEY: ((github-blinkbitcoin.private_key))
       run:
         path: pipeline-tasks/ci/tasks/gcp/bump-repos.sh
@@ -490,7 +490,7 @@ jobs:
       outputs:
       - name: repo
       params:
-        BRANCH: kn/scrub_project
+        BRANCH: main
         GOOGLE_CREDENTIALS: ((testflight-gcp-creds.creds_json))
       run:
         path: pipeline-tasks/ci/tasks/check-and-upgrade-k8s.sh
@@ -505,7 +505,7 @@ resources:
     ignore_paths:
     - ci/*[^md]
     uri: git@github.com:blinkbitcoin/blink-infra.git
-    branch: kn/scrub_project
+    branch: main
     private_key: ((github-blinkbitcoin.private_key))
   webhook_token: ((webhook.secret))
 - name: pipeline-tasks
@@ -516,7 +516,7 @@ resources:
     - ci/k8s-upgrade/*
     - Makefile
     uri: git@github.com:blinkbitcoin/blink-infra.git
-    branch: kn/scrub_project
+    branch: main
     private_key: ((github-blinkbitcoin.private_key))
 - name: galoy-staging
   type: git
@@ -535,7 +535,7 @@ resources:
     - modules/postgresql/gcp
     - modules/smoketest/gcp
     uri: git@github.com:blinkbitcoin/blink-infra.git
-    branch: kn/scrub_project
+    branch: main
     private_key: ((github-blinkbitcoin.private_key))
 - name: gcp-pipeline-image
   type: registry-image
@@ -550,7 +550,7 @@ resources:
     paths:
     - ci/image/gcp/Dockerfile
     uri: git@github.com:blinkbitcoin/blink-infra.git
-    branch: kn/scrub_project
+    branch: main
     private_key: ((github-blinkbitcoin.private_key))
 - name: gcp-testflight-uid
   type: semver

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -1,7 +1,7 @@
 #@data/values
 ---
 git_uri: git@github.com:blinkbitcoin/blink-infra.git
-git_branch: kn/scrub_project
+git_branch: main
 git_version_branch: testflight-name-prefix-uid-branch
 github_private_key: ((github-blinkbitcoin.private_key))
 

--- a/modules/platform/gcp/variables.tf
+++ b/modules/platform/gcp/variables.tf
@@ -10,7 +10,7 @@ variable "network_prefix" {
   default = "10.1"
 }
 variable "kube_version" {
-  default = "1.30.12-gke.1320000"
+  default = "1.31.8-gke.1045000"
 }
 variable "node_default_machine_type" {
   default = "n2-standard-4"


### PR DESCRIPTION
This PR is hopefully deployed to prod soon and resolves the current messy situation with the k8s versions on the different envs. Currently we have:

|                | STG                | PROD               |   |   |
|----------------|--------------------|--------------------|---|---|
| IS (cluster)   | 1.31.8-gke.1045000 | 1.31.8-gke.1045000 |   |   |
| IS (node pool) | 1.31.8-gke.1045000 | 1.30.9-gke.1127000 |   |   |

So this PR is setting the cluster version to `1.31.8-gke.1045000` mainly to upgrade the prod pool to that version.