### PR TITLE
chore: run upgrade check every day instead of every hour

### DIFF
--- a/ci/build/pipeline.yml
+++ b/ci/build/pipeline.yml
@@ -471,7 +471,7 @@ jobs:
 - name: check-and-upgrade-k8s
   plan:
   - in_parallel:
-    - get: every-1h
+    - get: every-1d
       trigger: true
     - get: repo
     - get: pipeline-tasks
@@ -574,11 +574,11 @@ resources:
     uri: git@github.com:blinkbitcoin/blink-infra-bootstrap-tfstate.git
     branch: main
     private_key: ((github-blinkbitcoin.private_key))
-- name: every-1h
+- name: every-1d
   type: time
   icon: clock-outline
   source:
-    interval: 1h
+    interval: 24h
 resource_types:
 - name: terraform
   type: docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -66,7 +66,7 @@ jobs:
 - name: check-and-upgrade-k8s
   plan:
   - in_parallel:
-    - get: every-1h
+    - get: every-1d
       trigger: true
     - get: repo
     - get: pipeline-tasks
@@ -101,10 +101,10 @@ resources:
 #@ for/end resource in gcp_resources():
 - #@ resource
 
-- name: every-1h
+- name: every-1d
   type: time
   icon: clock-outline
   source:
-    interval: 1h
+    interval: 24h
 
 resource_types: #@ resource_types()


### PR DESCRIPTION
It's not necessary to run that often and older job-executions get purged, bad for review.