### PR TITLE
fix: git clone in scrub_locks.sh

### DIFF
--- a/dev/scrub_locks.sh
+++ b/dev/scrub_locks.sh
@@ -5,7 +5,7 @@ TEMP_DIR=$(mktemp -d)
 trap "echo '    --> removing $TEMP_DIR' && rm -rf $TEMP_DIR" EXIT
 
 echo "    --> Cloning concourse-locks into $TEMP_DIR"
-git clone --depth 3 --single-branch --branch main --no-tags git@github.com:blinkbitcoin/concourse-locks.git "$TEMP_DIR/concourse-locks"
+git clone --depth 3 --single-branch --branch main --no-tags https://github.com/blinkbitcoin/concourse-locks "$TEMP_DIR/concourse-locks"
 
 cd "$TEMP_DIR/concourse-locks/gcp-infra-testflight"
 echo "    --> Unclaiming gcp-testflight"


### PR DESCRIPTION
Error before the change:
```
 blink-infra git:(main) ./dev/scrub_locks.sh
    --> Cloning concourse-locks into /var/folders/tc/j8qm1w9s7l765xz5dtg754000000gn/T/nix-shell.6u9Cpk/tmp.iBbti2KDlK
Cloning into '/var/folders/tc/j8qm1w9s7l765xz5dtg754000000gn/T/nix-shell.6u9Cpk/tmp.iBbti2KDlK/concourse-locks'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
./dev/scrub_locks.sh: line 10: cd: /var/folders/tc/j8qm1w9s7l765xz5dtg754000000gn/T/nix-shell.6u9Cpk/tmp.iBbti2KDlK/concourse-locks/gcp-infra-testflight: No such file or directory
    --> Unclaiming gcp-testflight
fatal: bad source, source=claimed/gcp-testflight, destination=unclaimed
    --> removing /var/folders/tc/j8qm1w9s7l765xz5dtg754000000gn/T/nix-shell.6u9Cpk/tmp.iBbti2KDlK
```

works with the change:
```
blink-infra git:(main) ./dev/scrub_locks.sh 
    --> Cloning concourse-locks into /var/folders/tc/j8qm1w9s7l765xz5dtg754000000gn/T/nix-shell.6u9Cpk/tmp.BExPCQYuDD
Cloning into '/var/folders/tc/j8qm1w9s7l765xz5dtg754000000gn/T/nix-shell.6u9Cpk/tmp.BExPCQYuDD/concourse-locks'...
remote: Enumerating objects: 27, done.
remote: Counting objects: 100% (27/27), done.
remote: Compressing objects: 100% (24/24), done.
remote: Total 27 (delta 5), reused 21 (delta 1), pack-reused 0 (from 0)
Receiving objects: 100% (27/27), done.
Resolving deltas: 100% (5/5), done.
    --> Unclaiming gcp-testflight
[main bb94552] manually unclaiming gcp-testflight
 1 file changed, 0 insertions(+), 0 deletions(-)
 rename gcp-infra-testflight/{claimed => unclaimed}/gcp-testflight (100%)
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 10 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 347 bytes | 347.00 KiB/s, done.
Total 3 (delta 1), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (1/1), completed with 1 local object.
To https://github.com/blinkbitcoin/concourse-locks
   b24c177..bb94552  main -> main
    --> removing /var/folders/tc/j8qm1w9s7l765xz5dtg754000000gn/T/nix-shell.6u9Cpk/tmp.BExPCQYuDD
```