### PR TITLE
chore(postgresql): add disk_size and disk_autoresize_limit to Cloud SQL module

### DIFF
--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -19,6 +19,10 @@ resource "google_sql_database_instance" "instance" {
     tier                        = local.tier
     availability_type           = local.highly_available ? "REGIONAL" : "ZONAL"
     deletion_protection_enabled = !local.destroyable
+    disk_autoresize             = true
+    disk_autoresize_limit       = local.disk_autoresize_limit
+    disk_size                   = local.disk_size_gb
+    disk_type                   = "PD_SSD"
 
     dynamic "database_flags" {
       for_each = local.prep_upgrade_as_source_db ? [{

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -112,6 +112,18 @@ variable "pre_promotion" {
   default     = false
 }
 
+variable "disk_size_gb" {
+  description = "Initial disk size in GB. If null, uses GCP default (10GB)."
+  type        = number
+  default     = null
+}
+
+variable "disk_autoresize_limit" {
+  description = "Maximum disk size in GB for auto-resize. 0 = unlimited (default GCP behavior)."
+  type        = number
+  default     = 0
+}
+
 locals {
   gcp_project                  = var.gcp_project
   vpc_name                     = var.vpc_name
@@ -144,5 +156,7 @@ locals {
   big_query_connection_location = var.big_query_connection_location
   prep_upgrade_as_source_db     = var.prep_upgrade_as_source_db
   pre_promotion                 = var.pre_promotion
+  disk_size_gb                  = var.disk_size_gb
+  disk_autoresize_limit         = var.disk_autoresize_limit
   database_port                 = 5432
 }


### PR DESCRIPTION
## Summary
- Add `disk_size_gb` and `disk_autoresize_limit` variables to the GCP Cloud SQL PostgreSQL module
- Configures `disk_autoresize`, `disk_autoresize_limit`, `disk_size`, and `disk_type` on the `google_sql_database_instance` resource
- Defaults preserve existing behavior (`null` disk_size = GCP default, `0` autoresize_limit = unlimited)

Cloud SQL disks auto-grow but can never shrink. This enables setting an initial size and capping auto-resize to prevent unbounded disk growth.

## Test plan
- [ ] Verify `terraform plan` shows no changes on existing instances (defaults match current behavior)
- [ ] Verify setting `disk_autoresize_limit` on an instance applies the cap
- [ ] Verify setting `disk_size_gb` on a new instance sets the initial size