### PR TITLE
fix: add access to custom log bucket

### DIFF
--- a/modules/inception/gcp/logs-viewer.tf
+++ b/modules/inception/gcp/logs-viewer.tf
@@ -4,3 +4,10 @@ resource "google_project_iam_member" "dev_read_log" {
   role     = "roles/logging.viewer"
   member   = each.key
 }
+
+resource "google_project_iam_member" "dev_read_log_views" {
+  project  = local.project
+  for_each = toset(local.log_viewers)
+  role     = "roles/logging.viewAccessor"
+  member   = each.key
+}


### PR DESCRIPTION
Applied manually with:
```
for member in \
  user:user@mail.com
do
  gcloud projects add-iam-policy-binding google-project \
    --member="$member" \
    --role="roles/logging.viewAccessor"
done
```

docs: https://docs.cloud.google.com/logging/docs/access-control#logging.viewAccessor