### PR TITLE
fix(ci): keep k8s upgrade check pinned to 1.33

### DIFF
--- a/ci/k8s-upgrade/main.tf
+++ b/ci/k8s-upgrade/main.tf
@@ -11,29 +11,31 @@ locals {
 }
 
 data "google_container_engine_versions" "uscentral1" {
-  provider = google-beta
-  location = "us-central1"
-  project  = local.project
+  provider       = google-beta
+  location       = "us-central1"
+  project        = local.project
+  version_prefix = local.version_prefix
 }
 
 data "google_container_engine_versions" "useast1" {
-  provider = google-beta
-  location = "us-east1"
-  project  = local.project
+  provider       = google-beta
+  location       = "us-east1"
+  project        = local.project
+  version_prefix = local.version_prefix
 }
 
 locals {
-  # Get the default version for the STABLE channel
+  # Get the latest version matching the pinned prefix for the STABLE channel.
   # see also here: https://cloud.google.com/kubernetes-engine/docs/release-notes
-  default_version = data.google_container_engine_versions.uscentral1.release_channel_default_version[local.channel]
+  latest_version = lookup(data.google_container_engine_versions.uscentral1.release_channel_latest_version, local.channel, null)
 }
 
 output "latest_version" {
-  description = "The default version from the STABLE channel."
-  value       = local.default_version
+  description = "The latest pinned-prefix version from the STABLE channel."
+  value       = local.latest_version
 
   precondition {
-    condition     = local.default_version != null && can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+-gke\\.[0-9]+$", local.default_version)) && (local.version_prefix == "" || startswith(local.default_version, local.version_prefix))
-    error_message = "The ${local.channel} channel returned an invalid default version: '${local.default_version}'. Expected format: X.Y.Z-gke.N and version prefix '${local.version_prefix}' (when configured)."
+    condition     = local.latest_version != null && can(regex("^[0-9]+\\.[0-9]+\\.[0-9]+-gke\\.[0-9]+$", local.latest_version)) && (local.version_prefix == "" || startswith(local.latest_version, local.version_prefix))
+    error_message = "The ${local.channel} channel returned no valid latest version for prefix '${local.version_prefix}' (when configured). Got: '${local.latest_version}'. Expected format: X.Y.Z-gke.N."
   }
 }


### PR DESCRIPTION
Use the configured version_prefix when querying GKE versions and select the Stable channel's latest matching version instead of the Stable default.

The Stable default has moved to 1.34, but this job is still intentionally guarded by the pinned 1.33 prefix, so the check should continue returning the latest available 1.33 patch version.